### PR TITLE
EasyECC improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on: [push]
+
+jobs:
+  moderate:
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-latest']
+        php-versions: ['7.1', '7.2', '7.3']
+        phpunit-versions: ['latest']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, sodium
+          ini-values: post_max_size=256M, max_execution_time=180
+          tools: psalm, phpunit:${{ matrix.phpunit-versions }}
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Modernize dependencies
+        run: composer require --dev "phpunit/phpunit:>=4"
+
+      - name: PHPUnit tests
+        uses: php-actions/phpunit@v2
+        timeout-minutes: 30
+        with:
+          memory_limit: 256M
+
+      - name: Static Analysis
+        run: vendor/bin/psalm
+
+  modern:
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-latest']
+        php-versions: ['7.4', '8.0']
+        phpunit-versions: ['latest']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, sodium
+          ini-values: post_max_size=256M, max_execution_time=180
+          tools: psalm, phpunit:${{ matrix.phpunit-versions }}
+
+      - name: Install dependencies
+        run: composer install
+      - name: PHPUnit tests
+        uses: php-actions/phpunit@v2
+        timeout-minutes: 30
+        with:
+          memory_limit: 256M
+
+      - name: Static Analysis
+        run: vendor/bin/psalm

--- a/README.md
+++ b/README.md
@@ -72,6 +72,46 @@ use ParagonIE\EasyECC\EasyECC;
 $ecc = new EasyECC('P384');
 ```
 
+### ECDSA-Specific Features
+
+```php
+<?php
+use ParagonIE\EasyECC\EasyECC;
+use ParagonIE\EasyECC\ECDSA\{PublicKey, SecretKey};
+
+// Generate an instance
+$ecc = new EasyECC('P256');
+
+// Get a keypair
+/** @var SecretKey $alice_sk */
+$alice_sk = $ecc->generatePrivateKey();
+/** @var PublicKey $alice_pk */
+$alice_pk = $alice_sk->getPublicKey();
+
+// Serialize as PEM (for OpenSSL compatibility):
+$alice_sk_pem = $alice_sk->exportPem();
+$alice_pk_pem = $alice_pk->exportPem();
+
+// Serialize public key as compressed point (for brevity):
+$alice_pk_cpt = $alice_pk->toString();
+
+// Signing a message (with PEM-formatted signatures):
+$message = 'This is extremely simple to use correctly.';
+
+// Signing a message (with IEEE-P1363-formatted signatures):
+$signature = $ecc->sign($message, $alice_sk, true);
+if (!$ecc->verify($message, $alice_pk, $signature, true)) {
+    throw new Exception('Signature validation failed');
+}
+
+// Let's do a key exchange:
+$bob_sk = $ecc->generatePrivateKey();
+$bob_pk = $alice_sk->getPublicKey();
+
+$alice_to_bob = $ecc->keyExchange($alice_sk, $bob_pk, true);
+$bob_to_alice = $ecc->keyExchange($bob_sk, $alice_pk, false);
+```
+
 ## Support Contracts
 
 If your company uses this library in their products or services, you may be

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
   },
   "require": {
     "php": "^7.1|^8",
+    "ext-gmp": "*",
     "defuse/php-encryption": "^2.1",
     "mdanter/ecc": "^1",
     "paragonie/sodium_compat": "^1.16",

--- a/src/ECDSA/PublicKey.php
+++ b/src/ECDSA/PublicKey.php
@@ -4,6 +4,7 @@ namespace ParagonIE\EasyECC\ECDSA;
 
 use FG\ASN1\Exception\ParserException;
 use Mdanter\Ecc\Crypto\Key\PublicKey as BasePublicKey;
+use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
 use Mdanter\Ecc\Curves\CurveFactory;
 use Mdanter\Ecc\EccFactory;
 use Mdanter\Ecc\Math\GmpMath;
@@ -50,6 +51,17 @@ class PublicKey extends BasePublicKey
     }
 
     /**
+     * Promote an instance of the base public key type to this type.
+     *
+     * @param PublicKeyInterface $key
+     * @return self
+     */
+    public static function promote(PublicKeyInterface $key): self
+    {
+        return new self(EccFactory::getAdapter(), $key->getGenerator(), $key->getPoint());
+    }
+
+    /**
      * @return string
      */
     public function toString(): string
@@ -71,19 +83,19 @@ class PublicKey extends BasePublicKey
      * @param string $curve
      * @return PublicKey
      */
-    public static function fromString(string $hexString, string $curve = EasyECC::DEFAULT_ECDSA_CURVE): self
-    {
+    public static function fromString(
+        string $hexString,
+        string $curve = EasyECC::DEFAULT_ECDSA_CURVE
+    ): self {
+        $adapter = EccFactory::getAdapter();
         switch ($curve) {
             case 'K256':
-                $adapter = EccFactory::getAdapter();
                 $generator = CurveFactory::getGeneratorByName('secp256k1');
                 break;
             case 'P256':
-                $adapter = EccFactory::getAdapter();
                 $generator = EccFactory::getNistCurves()->generator256();
                 break;
             case 'P384':
-                $adapter = EccFactory::getAdapter();
                 $generator = EccFactory::getNistCurves()->generator384();
                 break;
             default:

--- a/src/ECDSA/PublicKey.php
+++ b/src/ECDSA/PublicKey.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\EasyECC\ECDSA;
+
+use FG\ASN1\Exception\ParserException;
+use Mdanter\Ecc\Crypto\Key\PublicKey as BasePublicKey;
+use Mdanter\Ecc\Curves\CurveFactory;
+use Mdanter\Ecc\EccFactory;
+use Mdanter\Ecc\Math\GmpMath;
+use Mdanter\Ecc\Serializer\Point\CompressedPointSerializer;
+use Mdanter\Ecc\Serializer\PublicKey\DerPublicKeySerializer;
+use Mdanter\Ecc\Serializer\PublicKey\PemPublicKeySerializer;
+use ParagonIE\ConstantTime\Base64;
+use ParagonIE\EasyECC\EasyECC;
+
+/**
+ * Class PublicKey
+ * @package ParagonIE\EasyECC
+ */
+class PublicKey extends BasePublicKey
+{
+    /**
+     * @return string
+     */
+    public function exportPem(): string
+    {
+        $serializer = new PemPublicKeySerializer(new DerPublicKeySerializer());
+        return $serializer->serialize($this);
+    }
+
+    /**
+     * @param string $encoded
+     * @return self
+     * @throws ParserException
+     */
+    public static function importPem(string $encoded): self
+    {
+        $adapter = new GmpMath();
+        $serializer = new PublicKeyDerParser($adapter);
+
+        $encoded = str_replace('-----BEGIN PUBLIC KEY-----', '', $encoded);
+        $encoded = str_replace('-----END PUBLIC KEY-----', '', $encoded);
+
+        $data = Base64::decode($encoded);
+        $pk = $serializer->parse($data);
+        if (!($pk instanceof PublicKey)) {
+            throw new \TypeError('Parsed public key MUST be an instance of the inherited class.');
+        }
+        return $pk;
+    }
+
+    /**
+     * @return string
+     */
+    public function toString(): string
+    {
+        $serializer = new CompressedPointSerializer($this->getGenerator()->getAdapter());
+        return $serializer->serialize($this->getPoint());
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toString();
+    }
+
+    /**
+     * @param string $hexString
+     * @param string $curve
+     * @return PublicKey
+     */
+    public static function fromString(string $hexString, string $curve = EasyECC::DEFAULT_ECDSA_CURVE): self
+    {
+        switch ($curve) {
+            case 'K256':
+                $adapter = EccFactory::getAdapter();
+                $generator = CurveFactory::getGeneratorByName('secp256k1');
+                break;
+            case 'P256':
+                $adapter = EccFactory::getAdapter();
+                $generator = EccFactory::getNistCurves()->generator256();
+                break;
+            case 'P384':
+                $adapter = EccFactory::getAdapter();
+                $generator = EccFactory::getNistCurves()->generator384();
+                break;
+            default:
+                throw new \TypeError('This can only be used with ECDSA keys');
+        }
+        $serializer = new CompressedPointSerializer($adapter);
+        $point = $serializer->unserialize($generator->getCurve(), $hexString);
+        return new self($adapter, $generator, $point);
+    }
+}

--- a/src/ECDSA/PublicKeyDerParser.php
+++ b/src/ECDSA/PublicKeyDerParser.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\EasyECC\ECDSA;
+
+use Mdanter\Ecc\Crypto\Key\PublicKey;
+use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Serializer\PublicKey\Der\Parser;
+
+/**
+ * Class DerParser
+ * @package ParagonIE\EasyECC\ECDSA
+ */
+class PublicKeyDerParser extends Parser
+{
+    /**
+     * @param GeneratorPoint $generator
+     * @param string $data
+     * @return PublicKeyInterface
+     */
+    public function parseKey(GeneratorPoint $generator, string $data): PublicKeyInterface
+    {
+        /** @var PublicKey $pk */
+        $pk = parent::parseKey($generator, $data);
+        return new PublicKey(
+            $generator->getAdapter(),
+            $pk->getGenerator(),
+            $pk->getPoint()
+        );
+    }
+}

--- a/src/ECDSA/SecretKey.php
+++ b/src/ECDSA/SecretKey.php
@@ -2,7 +2,9 @@
 namespace ParagonIE\EasyECC\ECDSA;
 
 use Mdanter\Ecc\Crypto\Key\PrivateKey;
+use Mdanter\Ecc\Crypto\Key\PrivateKeyInterface;
 use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
+use Mdanter\Ecc\EccFactory;
 use Mdanter\Ecc\Math\GmpMath;
 use Mdanter\Ecc\Serializer\PrivateKey\DerPrivateKeySerializer;
 use Mdanter\Ecc\Serializer\PrivateKey\PemPrivateKeySerializer;
@@ -54,12 +56,20 @@ class SecretKey extends PrivateKey
      */
     public static function importPem(string $encoded): self
     {
-        $adapter = new GmpMath();
         $serializer = new PemPrivateKeySerializer(new DerPrivateKeySerializer());
         $sk = $serializer->parse($encoded);
         if (!($sk instanceof PrivateKey)) {
             throw new \TypeError('Parsed public key MUST be an instance of the inherited class.');
         }
-        return new self($adapter, $sk->getPoint(), $sk->getSecret());
+        return self::promote($sk);
+    }
+
+    /**
+     * @param PrivateKeyInterface $key
+     * @return self
+     */
+    public static function promote(PrivateKeyInterface $key): self
+    {
+        return new self(EccFactory::getAdapter(), $key->getPoint(), $key->getSecret());
     }
 }

--- a/src/ECDSA/SecretKey.php
+++ b/src/ECDSA/SecretKey.php
@@ -1,0 +1,65 @@
+<?php
+namespace ParagonIE\EasyECC\ECDSA;
+
+use Mdanter\Ecc\Crypto\Key\PrivateKey;
+use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
+use Mdanter\Ecc\Math\GmpMath;
+use Mdanter\Ecc\Serializer\PrivateKey\DerPrivateKeySerializer;
+use Mdanter\Ecc\Serializer\PrivateKey\PemPrivateKeySerializer;
+use ParagonIE\EasyECC\EasyECC;
+use ParagonIE\EasyECC\Exception\NotImplementedException;
+
+/**
+ * Class SecretKey
+ * @package ParagonIE\EasyECC
+ */
+class SecretKey extends PrivateKey
+{
+
+    /**
+     * @return string
+     */
+    public function exportPem(): string
+    {
+        $serializer = new PemPrivateKeySerializer(new DerPrivateKeySerializer());
+        return $serializer->serialize($this);
+    }
+
+    /**
+     * @return PublicKeyInterface
+     */
+    public function getPublicKey(): PublicKeyInterface
+    {
+        $adapter = new GmpMath();
+        $pk = parent::getPublicKey();
+        return new PublicKey($adapter, $pk->getGenerator(), $pk->getPoint());
+    }
+
+    /**
+     * @param string $curve
+     * @return self
+     * @throws NotImplementedException
+     */
+    public static function generate(string $curve = EasyECC::DEFAULT_ECDSA_CURVE): self
+    {
+        $generator = EasyECC::getGenerator($curve);
+        $sk = $generator->createPrivateKey();
+        $adapter = new GmpMath();
+        return new self($adapter, $generator, $sk->getSecret());
+    }
+
+    /**
+     * @param string $encoded
+     * @return self
+     */
+    public static function importPem(string $encoded): self
+    {
+        $adapter = new GmpMath();
+        $serializer = new PemPrivateKeySerializer(new DerPrivateKeySerializer());
+        $sk = $serializer->parse($encoded);
+        if (!($sk instanceof PrivateKey)) {
+            throw new \TypeError('Parsed public key MUST be an instance of the inherited class.');
+        }
+        return new self($adapter, $sk->getPoint(), $sk->getSecret());
+    }
+}

--- a/src/ECDSA/Signature.php
+++ b/src/ECDSA/Signature.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\EasyECC\ECDSA;
+
+use Mdanter\Ecc\Crypto\Signature\Signature as BaseSignature;
+use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
+use Mdanter\Ecc\Exception\SignatureDecodeException;
+use Mdanter\Ecc\Util\BinaryString;
+
+/**
+ * Class Signature
+ * @package ParagonIE\EasyECC
+ */
+class Signature extends BaseSignature
+{
+    /**
+     * Returns a hexadecimal-encoded signature.
+     *
+     * @param int $length
+     * @return string
+     */
+    public function toString(int $length = 0): string
+    {
+        $r = gmp_strval($this->getR(), 16);
+        $s = gmp_strval($this->getS(), 16);
+        $len = max(strlen($r), strlen($s), $length >> 1);
+        return str_pad($r, $len, '0', STR_PAD_LEFT) .
+            str_pad($s, $len, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * Returns a hexadecimal-encoded signature.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toString();
+    }
+
+    /**
+     * Promote an instance of the base signature type to this type.
+     *
+     * @param SignatureInterface $sig
+     * @return self
+     */
+    public static function promote(SignatureInterface $sig): self
+    {
+        return new self($sig->getR(), $sig->getS());
+    }
+
+    /**
+     * Serializes a signature from a hexadecimal string.
+     *
+     * @param string $hexString
+     * @return self
+     * @throws \SodiumException
+     */
+    public static function fromString(string $hexString): self
+    {
+        $binary = sodium_hex2bin($hexString);
+        $total_length = BinaryString::length($binary);
+        if (($total_length & 1) !== 0) {
+            throw new SignatureDecodeException('IEEE-P1363 signatures must be an even length');
+        }
+        $piece_len = $total_length >> 1;
+        $r = bin2hex(BinaryString::substring($binary, 0, $piece_len));
+        $s = bin2hex(BinaryString::substring($binary, $piece_len, $piece_len));
+
+        return new self(gmp_init($r, 16), gmp_init($s, 16));
+    }
+}

--- a/tests/ECDSA/SignatureTest.php
+++ b/tests/ECDSA/SignatureTest.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+namespace ECDSA;
+
+use FG\ASN1\Exception\ParserException;
+use Mdanter\Ecc\Util\BinaryString;
+use ParagonIE\EasyECC\EasyECC;
+use ParagonIE\EasyECC\ECDSA\PublicKey;
+use ParagonIE\EasyECC\ECDSA\SecretKey;
+use ParagonIE\EasyECC\Exception\ConfigException;
+use ParagonIE\EasyECC\Exception\NotImplementedException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class SignatureTest
+ * @package ECDSA
+ *
+ * @covers \ParagonIE\EasyECC\ECDSA\SecretKey
+ * @covers \ParagonIE\EasyECC\ECDSA\PublicKey
+ * @covers \ParagonIE\EasyECC\ECDSA\Signature
+ */
+class SignatureTest extends TestCase
+{
+    const PUBKEY_SIZES = [
+        'K256' => 33,
+        'P256' => 33,
+        'P384' => 49
+    ];
+
+    /**
+     * @throws NotImplementedException
+     * @throws ParserException
+     * @throws ConfigException
+     * @throws \SodiumException
+     */
+    public function testSign()
+    {
+        $msg = 'this is a test message';
+        foreach (EasyECC::CURVES as $curve) {
+            if (!array_key_exists($curve, EasyECC::SIGNATURE_SIZES)) {
+                // Not an ECDSA curve
+                continue;
+            }
+            $sk = SecretKey::generate($curve);
+            /** @var PublicKey $pk */
+            $pk = $sk->getPublicKey();
+            $this->assertInstanceOf(PublicKey::class, $pk);
+            $this->assertSame(
+                self::PUBKEY_SIZES[$curve],
+                BinaryString::length($pk->toString()) >> 1,
+                'Compressed public keys must be the correct length'
+            );
+
+            $ecc = new EasyECC($curve);
+            $signature = $ecc->sign($msg, $sk, true);
+            $this->assertSame(
+                EasyECC::SIGNATURE_SIZES[$curve],
+                BinaryString::length($signature) >> 1,
+                'IEEE-P1363 formatted signatures must be the correct length'
+            );
+
+            $this->assertTrue(
+                $ecc->verify($msg, $pk, $signature, true),
+                'ECDSA signature must validate'
+            );
+
+            $this->assertFalse(
+                $ecc->verify($msg . ' foo', $pk, $signature, true),
+                'Invalid ECDSA signature must not validate'
+            );
+        }
+    }
+}


### PR DESCRIPTION
- EasyECC::sign() can now return IEEE-P1363 formatted signatures
- EasyECC::verify() can now accept them
- Extended the base PrivateKey/PublicKey classes to reduce boilerplate.