### PR TITLE
Support seal/unseal operations

### DIFF
--- a/src/Curve25519/EdwardsPublicKey.php
+++ b/src/Curve25519/EdwardsPublicKey.php
@@ -7,6 +7,7 @@ use Mdanter\Ecc\Primitives\CurveFpInterface;
 use Mdanter\Ecc\Primitives\GeneratorPoint;
 use Mdanter\Ecc\Primitives\PointInterface;
 use ParagonIE\ConstantTime\Binary;
+use ParagonIE\ConstantTime\Hex;
 use ParagonIE\EasyECC\Exception\NotImplementedException;
 
 /**
@@ -46,7 +47,17 @@ class EdwardsPublicKey implements PublicKeyInterface
      */
     public function toString(): string
     {
-        return $this->publicKey;
+        return Hex::encode($this->publicKey);
+    }
+
+    /**
+     * @param string $str
+     * @return self
+     * @throws \SodiumException
+     */
+    public static function fromString(string $str): self
+    {
+        return new EdwardsPublicKey(Hex::decode($str));
     }
 
     /**

--- a/src/ECDSA/PublicKey.php
+++ b/src/ECDSA/PublicKey.php
@@ -100,14 +100,21 @@ class PublicKey extends BasePublicKey
                 $generator = EccFactory::getNistCurves()->generator256();
                 $namedCurve = EccFactory::getNistCurves()->curve256();
                 if (Binary::safeStrlen($hexString) !== 66) {
-                    throw new InvalidPublicKeyException('Public key is  the wrong size for ' . $curve);
+                    throw new InvalidPublicKeyException('Public key is the wrong size for ' . $curve);
                 }
                 break;
             case 'P384':
                 $generator = EccFactory::getNistCurves()->generator384();
                 $namedCurve = EccFactory::getNistCurves()->curve384();
                 if (Binary::safeStrlen($hexString) !== 98) {
-                    throw new InvalidPublicKeyException('Public key is  the wrong size for ' . $curve);
+                    throw new InvalidPublicKeyException('Public key is the wrong size for ' . $curve);
+                }
+                break;
+            case 'P521':
+                $generator = EccFactory::getNistCurves()->generator521();
+                $namedCurve = EccFactory::getNistCurves()->curve521();
+                if (Binary::safeStrlen($hexString) !== 134) {
+                    throw new InvalidPublicKeyException('Public key is the wrong size for ' . $curve);
                 }
                 break;
             default:

--- a/src/EasyECC.php
+++ b/src/EasyECC.php
@@ -284,6 +284,27 @@ class EasyECC
     }
 
     /**
+     * @return int
+     * @throws NotImplementedException
+     */
+    public function getPublicKeyLength(): int
+    {
+        switch ($this->curve) {
+            case 'sodium':
+                return 64;
+            case 'K256':
+            case 'P256':
+                return 66;
+            case 'P384':
+                return 98;
+            case 'P521':
+                return 134;
+            default:
+                throw new NotImplementedException("Unknown curve");
+        }
+    }
+
+    /**
      * @param string $curve
      * @param bool $constantTime
      * @return GeneratorPoint

--- a/src/EncryptionInterface.php
+++ b/src/EncryptionInterface.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\EasyECC;
+
+use Mdanter\Ecc\Crypto\Key\PrivateKeyInterface;
+use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
+
+interface EncryptionInterface
+{
+    public function __construct(EasyECC $ecc);
+
+    public function asymmetricEncrypt(
+        string $message,
+        PrivateKeyInterface $privateKey,
+        PublicKeyInterface $publicKey
+    ): string;
+
+    public function asymmetricDecrypt(
+        string $message,
+        PrivateKeyInterface $privateKey,
+        PublicKeyInterface $publicKey
+    ): string;
+
+    public function seal(
+        string $message,
+        PublicKeyInterface $publicKey
+    ): string;
+
+    public function unseal(
+        string $message,
+        PrivateKeyInterface $privateKey
+    ): string;
+}

--- a/tests/EasyECCTest.php
+++ b/tests/EasyECCTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\EasyECC\Tests;
 
+use ParagonIE\ConstantTime\Binary;
 use ParagonIE\ConstantTime\Hex;
 use ParagonIE\EasyECC\EasyECC;
 use ParagonIE\EasyECC\ECDSA\PublicKey;
@@ -50,6 +51,8 @@ class EasyECCTest extends TestCase
         $bobSK = $ecc->generatePrivateKey();
         /** @var PublicKey $bobPK */
         $bobPK = $bobSK->getPublicKey();
+
+        $this->assertSame($ecc->getPublicKeyLength(), Binary::safeStrlen($bobPK->toString()));
 
         $this->assertNotSame(
             $alicePK->toString(),

--- a/tests/EasyECCTest.php
+++ b/tests/EasyECCTest.php
@@ -18,7 +18,7 @@ class EasyECCTest extends TestCase
         $this->assertSame('sodium', $ecc->getCurveName());
     }
 
-    private function easyEccCurves()
+    public function easyEccCurves()
     {
         return [
             [new EasyECC()],
@@ -36,7 +36,7 @@ class EasyECCTest extends TestCase
      * @throws NotImplementedException
      * @throws SodiumException
      */
-    public function testCongruentOps(EasyECC $ecc)
+    public function testCongruentOps(EasyECC $ecc): void
     {
         $aliceSK = $ecc->generatePrivateKey();
         /** @var PublicKey $alicePK */

--- a/tests/Integration/DefuseTest.php
+++ b/tests/Integration/DefuseTest.php
@@ -168,7 +168,7 @@ class DefuseTest extends TestCase
         );
     }
 
-    private function easyEccCurves()
+    public function easyEccCurves(): array
     {
         return [
             [new EasyECC()],
@@ -182,7 +182,7 @@ class DefuseTest extends TestCase
     /**
      * @dataProvider easyEccCurves
      */
-    public function testSeal(EasyECC $ecc)
+    public function testSeal(EasyECC $ecc): void
     {
         $defuse = new Defuse($ecc);
         $alice_sk = $ecc->generatePrivateKey();


### PR DESCRIPTION
This adds an interface called `EncryptionInterface` which can be used to extend EasyECC to support multiple encryption backends.

It also adds a dedicated `seal()` / `unseal()` operation for anonymous public-key encryption.