### PR TITLE
Use paragonie/ecc v2.1.0 or older

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "php": "^7.1|^8",
     "ext-gmp": "*",
     "defuse/php-encryption": "^2.1",
-    "paragonie/ecc": "^2",
+    "paragonie/ecc": "^2.1",
     "paragonie/sodium_compat": "^1|^2",
     "paragonie/constant_time_encoding": "^2.1"
   },

--- a/src/Curve25519/X25519.php
+++ b/src/Curve25519/X25519.php
@@ -96,7 +96,7 @@ class X25519 implements EcDHInterface
      * Sets the sender's key.
      *
      * @param PrivateKeyInterface $key
-     * @return void
+     * @return self
      * @throws \SodiumException
      * @throws \TypeError
      */
@@ -109,13 +109,14 @@ class X25519 implements EcDHInterface
         } else {
             throw new \TypeError('Only libsodium keys are allowed');
         }
+        return $this;
     }
 
     /**
      * Sets the recipient key.
      *
      * @param  PublicKeyInterface $key
-     * @return void
+     * @return self
      * @throws \SodiumException
      * @throws \TypeError
      */
@@ -128,5 +129,6 @@ class X25519 implements EcDHInterface
         } else {
             throw new \TypeError('Only libsodium keys are allowed');
         }
+        return $this;
     }
 }

--- a/src/ECDSA/HedgedRandomNumberGenerator.php
+++ b/src/ECDSA/HedgedRandomNumberGenerator.php
@@ -141,7 +141,7 @@ class HedgedRandomNumberGenerator implements RandomNumberGeneratorInterface
         $v = hash_hmac($this->algorithm, $v, $k, true);
 
         $t = '';
-        for (;;) {
+        for ($tries = 0; $tries < 1024; ++$tries) {
             $toff = gmp_init(0, 10);
             while ($this->math->cmp($toff, $rlen) < 0) {
                 $v = hash_hmac($this->algorithm, $v, $k, true);

--- a/src/EasyECC.php
+++ b/src/EasyECC.php
@@ -11,6 +11,7 @@ use Mdanter\Ecc\Curves\CurveFactory;
 use Mdanter\Ecc\EccFactory;
 use Mdanter\Ecc\Math\GmpMathInterface;
 use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Random\RandomGeneratorFactory;
 use Mdanter\Ecc\Serializer\PublicKey\DerPublicKeySerializer;
 use Mdanter\Ecc\Serializer\Signature\DerSignatureSerializer;
 use Mdanter\Ecc\Util\NumberSize;
@@ -76,13 +77,19 @@ class EasyECC
                 break;
             case 'P256':
                 $this->adapter = EccFactory::getAdapter();
-                $this->generator = EccFactory::getNistCurves()->generator256();
+                $this->generator = EccFactory::getNistCurves()->generator256(
+                    RandomGeneratorFactory::getRandomGenerator(),
+                    true
+                );
                 $this->hashAlgo = 'sha256';
                 $this->hasher = new SignHasher($this->hashAlgo, $this->adapter);
                 break;
             case 'P384':
                 $this->adapter = EccFactory::getAdapter();
-                $this->generator = EccFactory::getNistCurves()->generator384();
+                $this->generator = EccFactory::getNistCurves()->generator384(
+                    RandomGeneratorFactory::getRandomGenerator(),
+                    true
+                );
                 $this->hashAlgo = 'sha384';
                 $this->hasher = new SignHasher($this->hashAlgo, $this->adapter);
                 break;
@@ -320,12 +327,18 @@ class EasyECC
                 return CurveFactory::getGeneratorByName('secp256k1');
             case 'P256':
                 if ($constantTime) {
-                    return EccFactory::getNistCurves(new ConstantTimeMath())->generator256();
+                    return EccFactory::getNistCurves(new ConstantTimeMath())->generator256(
+                        RandomGeneratorFactory::getRandomGenerator(),
+                        true
+                    );
                 }
                 return EccFactory::getNistCurves()->generator256();
             case 'P384':
                 if ($constantTime) {
-                    return EccFactory::getNistCurves(new ConstantTimeMath())->generator384();
+                    return EccFactory::getNistCurves(new ConstantTimeMath())->generator384(
+                        RandomGeneratorFactory::getRandomGenerator(),
+                        true
+                    );
                 }
                 return EccFactory::getNistCurves()->generator384();
             case 'P521':


### PR DESCRIPTION
Switches to constant-time implementations by default