### PR TITLE
Use the corresponding hash algorithm, rather than always sha384

### DIFF
--- a/src/EasyECC.php
+++ b/src/EasyECC.php
@@ -221,7 +221,7 @@ class EasyECC
             EccFactory::getAdapter(),
             $privateKey,
             $hash,
-            'sha384'
+            $this->hashAlgo
         );
         $k = $kGen->generate($this->generator->getOrder());
 


### PR DESCRIPTION
This has no security impact, but may violate the principle of least astonishment for people using, e.g., secp256k1

See #10